### PR TITLE
Derive commonly required traits for `Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,7 @@ pub type Result<T, E> = ::core::result::Result<T, Error<E>>;
 ///
 /// The main use of this enum is to add a `WouldBlock` variant to an existing
 /// error enum.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Error<E> {
     /// A different kind of error
     Other(E),


### PR DESCRIPTION
I only need `PartialEq`/`Eq`, but figured I'd add other commonly
required traits while I'm at it. I looked at the Rust core library and
just derived all traits that `Option` derives, so I don't think I forgot
anything important.