### PR TITLE
io::{Read,Write} traits

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,5 @@
+mod read;
+mod write;
+
+pub use self::read::Read;
+pub use self::write::Write;

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,0 +1,43 @@
+use core::cmp;
+
+use Result;
+
+/// Non-blocking reader trait
+pub trait Read {
+    /// An enumeration of possible errors
+    ///
+    /// May be `!` (`never_type`) for infallible implementations
+    type Error;
+
+    /// Pull some bytes from this source into the specified buffer, returning how many bytes were
+    /// read.
+    ///
+    /// If an object needs to block for a read it will return an `Err(nb::Error::WouldBlock)`
+    /// return value.
+    ///
+    /// If the return value of this method is `Ok(n)`, then it must be guaranteed that `0 <= n <=
+    /// buf.len()`. The `n` value indicates that the buffer `buf` has been filled in with `n` bytes
+    /// of data from this source. If `n == 0 && buf.len() > 0` then it can be assumed that this
+    /// reader has run out of data and will not be able service any future read calls.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
+impl<'a, R: ?Sized + Read> Read for &'a mut R {
+    type Error = R::Error;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        (**self).read(buf)
+    }
+}
+
+impl<'a> Read for &'a [u8] {
+    type Error = !;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let len = cmp::min(self.len(), buf.len());
+        let (head, tail) = self.split_at(len);
+        buf[..len].copy_from_slice(head);
+        *self = tail;
+        Ok(len)
+    }
+}

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -1,0 +1,73 @@
+use core::{cmp, mem};
+
+use Result;
+
+/// Non-blocking writer trait
+pub trait Write {
+    /// An enumeration of possible errors
+    ///
+    /// May be `!` (`never_type`) for infallible implementations
+    type Error;
+
+    /// Push some bytes into this source from the specified buffer, returning how many bytes were
+    /// written.
+    ///
+    /// If an object needs to block for a write it will return an `Err(nb::Error::WouldBlock)`
+    /// return value.
+    ///
+    /// If the return value of this method is `Ok(n)`, then it must be guaranteed that `0 <= n <=
+    /// buf.len()`. The `n` value indicates that `n` bytes from the buffer `buf` have been written
+    /// to this source. If `n == 0 && buf.len() > 0` then it can be assumed that this writer has
+    /// run out of space and will not be able to service future writes.
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
+
+    /// Attempt to flush the object, ensuring that any buffered data reach their destination.
+    ///
+    /// On success, returns `Ok(())`.
+    ///
+    /// If flushing cannot immediately complete, this method returns `Err(nb::Error::WouldBlock)`.
+    fn flush(&mut self) -> Result<(), Self::Error>;
+
+    /// Attempt to close the object.
+    ///
+    /// On success, returns `Ok(())`.
+    ///
+    /// If closing cannot immediately complete, this method returns `Err(nb::Error::WouldBlock)`.
+    fn close(&mut self) -> Result<(), Self::Error>;
+}
+
+impl<'a, W: ?Sized + Write> Write for &'a mut W {
+    type Error = W::Error;
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        (**self).write(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        (**self).flush()
+    }
+
+    fn close(&mut self) -> Result<(), Self::Error> {
+        (**self).close()
+    }
+}
+
+impl<'a> Write for &'a mut [u8] {
+    type Error = !;
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let len = cmp::min(self.len(), buf.len());
+        let (head, tail) = mem::replace(self, &mut []).split_at_mut(len);
+        head.copy_from_slice(&buf[..len]);
+        *self = tail;
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,11 @@
 #![no_std]
 #![deny(warnings)]
 
+#![cfg_attr(feature = "unstable", feature(never_type))]
+
+#[cfg(feature = "unstable")]
+pub mod io;
+
 use core::fmt;
 
 /// A non-blocking result


### PR DESCRIPTION
I mentioned on https://github.com/japaric/embedded-hal/pull/56 that it seems like a good idea for `embedded_hal` to provide base io traits similar to the ones in `std`. After a bit more thought I decided that they should probably be somewhere a little more fundamental than `embedded_hal` so even non-HAL using code could be based off them.

I'm not certain that `nb` itself should be the place to include these, or whether it would make sense to have a separate `nb-io` crate for them.

I'm relatively unhappy about adding a _third_ set of these traits to the ecosystem (on top of the `std` ones and the `futures-io` ones, and maybe there are others I'm unaware of). It's also disappointing that these can't be compatible with the `futures-utils::io` adaptors, so like the example `read_exact` and `write_all` adaptors I've added they'll have to be rewritten for `nb::io`. But without something like the `futures-io` crate switching to an associated error type like these to avoid the `std::io::Error` dependency, I don't see any other way to do this; and I really don't think the futures ecosystem would like the ergonomic hit introducing that associated type would bring.