### PR TITLE
Add block_while! macro that blocks while another expression evaluates to true

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,7 @@ macro_rules! block {
 /// # Output
 ///
 /// - `Ok(t)` if `$e` evaluates to `Ok(t)`
-/// - `Err(e)` if `$e` evaluates to `Err(nb::Error::Other(e))`
+/// - `Err(nb::Error::Other(e))` if `$e` evaluates to `Err(nb::Error::Other(e))`
 /// - `Err(Error::WouldBlock)` if `$e` evaluates to `Err(Error::WouldBlock)` and `$c` evaluates to false
 #[macro_export]
 macro_rules! block_while {
@@ -498,7 +498,7 @@ macro_rules! block_while {
             match $e {
                 Err($crate::Error::Other(e)) => {
                     #[allow(unreachable_code)]
-                    break Err(e)
+                    break Err($crate::Error::Other(e))
                 },
                 Err($crate::Error::WouldBlock) => {
                     if !$c {


### PR DESCRIPTION
I am using this macro derivative for an private project for a while now and decided to see whether others (like you) can make use of it as well. Basically it adds a condition to ```block!``` so that it does not block indefinitely. This allows code like this:

```rust
// ...
        let time = || info.uptime_ms();
        let timeout = time() + 500;
        let in_time = || timeout > time();

        block_while!(in_time(), tx.write(START_BYTE))
            .and(block_while!(in_time(), tx.write(0x01)))
            .and(block_while!(in_time(), tx.write(COMMAND)))
            .and(block_while!(in_time(), tx.write(0x00)))
            .and(block_while!(in_time(), tx.write(0x00)))
            .and(block_while!(in_time(), tx.write(0x00)))
            .and(block_while!(in_time(), tx.write(0x00)))
            .and(block_while!(in_time(), tx.write(0x00)))
            .and(block_while!(in_time(), tx.write(0x79)))
            .map_err(drop)
            .and_then(|_| {
                Ok([
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                    block_while!(in_time(), rx.read()).map_err(drop)?,
                ])
            })
// ...
```

The operation is still blocking but in this case with a timeout.